### PR TITLE
Rails and postcss-assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,30 @@ To define a custom cachebuster pass a function as an option:
 
 ```js
 var options = {
-  cachebuster: function (path) {
-    return fs.statSync(path).mtime.getTime().toString(16);
+  cachebuster: function (filePath, urlPathname) {
+    return fs.statSync(filePath).mtime.getTime().toString(16);
+  }
+};
+```
+
+If the returned value is falsy, no cache busting is done for the asset.
+
+If the returned value is an object the values of `pathname` and/or `query` are used to generate a cache busted path to the asset.
+
+If the returned value is a string, it is added as a query string.
+
+The returned values for query strings must not include the starting `?`.
+
+Busting the cache via path:
+
+```js
+var options = {
+  cachebuster: function (resolvedFilePath, resolvedUrlPathname) {
+    var hash = fs.statSync(resolvedFilePath).mtime.getTime().toString(16);
+    return {
+      pathname: path.dirname(resolvedUrlPathname) + '/' + path.basename(resolvedUrlPathname, path.extname(resolvedUrlPathname)) + hash + path.extname(resolvedUrlPathname),
+      query: false // you may omit this one
+    }
   }
 };
 ```

--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ var options = {
   cachebuster: function (filePath, urlPathname) {
     var hash = fs.statSync(filePath).mtime.getTime().toString(16);
     return {
-      pathname: path.dirname(urlPathname) + '/' + path.basename(urlPathname, path.extname(urlPathname)) + hash + path.extname(urlPathname),
+      pathname: path.dirname(urlPathname)
+        + '/' + path.basename(urlPathname, path.extname(urlPathname))
+        + hash + path.extname(urlPathname),
       query: false // you may omit this one
     }
   }

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ Busting the cache via path:
 
 ```js
 var options = {
-  cachebuster: function (resolvedFilePath, resolvedUrlPathname) {
-    var hash = fs.statSync(resolvedFilePath).mtime.getTime().toString(16);
+  cachebuster: function (filePath, urlPathname) {
+    var hash = fs.statSync(filePath).mtime.getTime().toString(16);
     return {
-      pathname: path.dirname(resolvedUrlPathname) + '/' + path.basename(resolvedUrlPathname, path.extname(resolvedUrlPathname)) + hash + path.extname(resolvedUrlPathname),
+      pathname: path.dirname(urlPathname) + '/' + path.basename(urlPathname, path.extname(urlPathname)) + hash + path.extname(urlPathname),
       query: false // you may omit this one
     }
   }

--- a/index.js
+++ b/index.js
@@ -119,8 +119,8 @@ Assets.prototype.resolveUrl = function (assetStr) {
           assetUrl.search = '?' + cachebusterOutput;
         }
       }
-      if (cachebusterOutput.path) {
-        assetUrl.pathname = cachebusterOutput.path;
+      if (cachebusterOutput.pathname) {
+        assetUrl.pathname = cachebusterOutput.pathname;
       }
       if (cachebusterOutput.query) {
         if (assetUrl.search) {

--- a/test/assets.js
+++ b/test/assets.js
@@ -111,9 +111,9 @@ describe('resolve', function () {
 
   it('should accept custom buster function returning an object', function () {
     compareFixtures('cachebuster-object', {
-      cachebuster: function (pathString, urlString) {
+      cachebuster: function (filePath, urlPathname) {
         return {
-          path: path.dirname(urlString) + '/' + path.basename(urlString, path.extname(urlString)) + '.cache' + path.extname(urlString),
+          pathname: path.dirname(urlPathname) + '/' + path.basename(urlPathname, path.extname(urlPathname)) + '.cache' + path.extname(urlPathname),
           query: 'buster'
         };
       },
@@ -123,7 +123,7 @@ describe('resolve', function () {
 
   it('should accept custom buster function returning a falsy value', function () {
     compareFixtures('cachebuster-falsy', {
-      cachebuster: function (pathString, urlString) {
+      cachebuster: function (filePath, urlPathname) {
         return;
       },
       loadPaths: ['test/fixtures/alpha/']

--- a/test/fixtures/cachebuster-falsy.css
+++ b/test/fixtures/cachebuster-falsy.css
@@ -1,0 +1,3 @@
+body {
+  background: resolve('kateryna.jpg?foo');
+}

--- a/test/fixtures/cachebuster-falsy.expected.css
+++ b/test/fixtures/cachebuster-falsy.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url('/test/fixtures/alpha/kateryna.jpg?foo');
+}

--- a/test/fixtures/cachebuster-object.css
+++ b/test/fixtures/cachebuster-object.css
@@ -1,0 +1,3 @@
+body {
+  background: resolve('kateryna.jpg?foo');
+}

--- a/test/fixtures/cachebuster-object.expected.css
+++ b/test/fixtures/cachebuster-object.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url('/test/fixtures/alpha/kateryna.cache.jpg?foo&buster');
+}

--- a/test/fixtures/cachebuster-string.css
+++ b/test/fixtures/cachebuster-string.css
@@ -1,0 +1,3 @@
+body {
+  background: resolve('kateryna.jpg?foo');
+}

--- a/test/fixtures/cachebuster-string.expected.css
+++ b/test/fixtures/cachebuster-string.expected.css
@@ -1,0 +1,3 @@
+body {
+  background: url('/test/fixtures/alpha/kateryna.jpg?foo&cachebuster');
+}


### PR DESCRIPTION
Hi, I'm using postcss-assets with Rails-style cachebuster: `application-7a0306d552d84deaa57f0af77c99a8ed.js`. As you can see It's not query string based. It would be nice to change the `cachebuster` callback in order to support this. Or pass in an argument with assets paths: `{'application': application-7a0306d552d84deaa57f0af77c99a8ed.js}`.