### PR TITLE
Fix PostCSS plugin API

### DIFF
--- a/index.js
+++ b/index.js
@@ -269,5 +269,8 @@ Assets.prototype.postcss = function (css) {
 };
 
 module.exports = postcss.plugin('postcss-assets', function (options) {
-  return new Assets(options);
+    var assets = new Assets(options);
+    return function (css) {
+        return assets.postcss(css);
+    };
 });


### PR DESCRIPTION
Right now `postcss-assets` do not use common PostCSS plugin API, because we need to return function from `postcss.plugin`. As result plugin will throw a bad readable error if you forget brackets.