### PR TITLE
Allow query strings to be second argument of resolve.

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,8 +227,13 @@ Assets.prototype.postcss = function (css) {
       decl.value = mapFunctions(decl.value, {
 
         // Get URL to an asset file
-        resolve: function (assetStr) {
+        resolve: function (assetStr, queryString) {
           assetStr.value = self.resolveUrl(assetStr.value);
+
+          if (queryString && queryString.value) {
+            assetStr.value += '?' + queryString.value;
+          }
+
           return 'url(' + assetStr + ')';
         },
 


### PR DESCRIPTION
# Intro

This modification allows us to use `background-image: resolve(url [, queryString])`to optionally add a query string to the end of the resolved filename.

If this is something you'd be interested in merging in, please give me a little guidance and I'll also update the readme to reflect the new option.

# Logic
I'm using imgix for production images. Imgix allows me to host a single high resolution file and then use imgix's CDN to serve variations of that single file depending on query strings. 

For development, I serve up local images from `./tmp/public/images` (using sails). For production I serve the images from imgix. I use `basePath` and `baseUrl` in my gulp configuration like so:

```
plugins.postcssAssets({
    loadPaths: [
        '../assets/images/',
    ],
    basePath: process.env.NODE_ENV === 'production' ? './tmp/public/images' : 'assets',
    baseUrl: process.env.NODE_ENV === 'production' ? 'https://constantadvisor.imgix.net' : '/',
}),
```

# Example

```
background-image: resolve('image.jpg', 'dpr=2')
```

The path `image.jpg` will aways resolve using `loadPaths` (`../assets/images`). The output would then vary for production or development:

## development

```css
background-image: url('/images/image.jpg?dpr=2');
```

## production

```css
background-image: url('https://constantadvisor.imgix.net/image.jpg?dpr=2')
```