### PR TITLE
Fails to install via npm on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postcss-assets",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "PostCSS plugin to manage assets",
   "keywords": [
     "css",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "cssesc": "^0.1.0",
     "directory-encoder": "^0.7.2",
     "gonzales": "^1.0.7",
-    "image-size": "borodean/image-size",
+    "image-size": "https://github.com/borodean/image-size/archive/da2c863807a3e9602617bdd357b0de3ab4a064c1.tar.gz",
     "mime": "^1.3.4",
     "postcss": "^5.0.0"
   },


### PR DESCRIPTION
No problem installing this plugin on my Mac system but when a fellow dev tries to install on a Windows 7 machine it fails to load. I believe it's to do with the way the path is specified to image-size: https://github.com/borodean/postcss-assets/blob/develop/package.json#L21

Is it possible change this to a full git url? Haven't done a PR for this incase there is a specific reason you don't want it that way.