### PR TITLE
Add note about where options parameters should go.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ grunt.initConfig({
 });
 ```
 
+**Note: all of the listed options below are parameters for the ```assets``` object, not the top level postcss options object.**
+
 URL resolution
 --------------
 


### PR DESCRIPTION
We struggled a bit trying to get cachebuster to work because it wasn't entirely clear the parameter should go inside the assets object, and not the postcss object. I edited the readme to make this explicit.