### PR TITLE
Add ability to specify unit and unit base when outputting image dimensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,16 @@ body {
 }
 ```
 
+To specify a different unit and unit base, pass them as the third and fourth parameters:
+
+```css
+body {
+  width: width('images/foobar.png', 1, 'em', 16); /* 20em */
+  height: height('images/foobar.png', 1, 'em', 16); /* 15em */
+  background-size: size('images/foobar.png', 1, 'em', 16); /* 20em 15em */
+}
+```
+
 Inlining files
 --------------
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ body {
   width: width('images/foobar.png'); /* 320px */
   height: height('images/foobar.png'); /* 240px */
   background-size: size('images/foobar.png'); /* 320px 240px */
+  padding-top: ratio('images/foobar.png'); /* 75% */
 }
 ```
 
@@ -218,6 +219,7 @@ body {
   width: width('images/foobar.png', 2); /* 160px */
   height: height('images/foobar.png', 2); /* 120px */
   background-size: size('images/foobar.png', 2); /* 160px 120px */
+  padding-top: ratio('images/foobar.png'); /* 75% */
 }
 ```
 
@@ -228,6 +230,7 @@ body {
   width: width('images/foobar.png', 1, 'em', 16); /* 20em */
   height: height('images/foobar.png', 1, 'em', 16); /* 15em */
   background-size: size('images/foobar.png', 1, 'em', 16); /* 20em 15em */
+  padding-top: ratio('images/foobar.png'); /* 75% */
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ function plugin(options) {
       })
       .then(function round(size) {
         return {
-          width: size.width.toFixed(4),
-          height: size.height.toFixed(4)
+          width: size.width.toFixed(8),
+          height: size.height.toFixed(8)
         };
       });
   }

--- a/index.js
+++ b/index.js
@@ -23,6 +23,10 @@ function formatHeight(unit, measurements) {
   return util.format('%d' + unit, measurements.height);
 }
 
+function formatRatio(measurements) {
+  return util.format('%d' + '%', measurements.ratio * 100);
+}
+
 function plugin(options) {
   var params = options || {};
   var resolver;
@@ -57,6 +61,15 @@ function plugin(options) {
         return {
           width: size.width.toFixed(8),
           height: size.height.toFixed(8)
+        };
+      });
+  }
+
+  function measureRatio(path) {
+    return resolver.size(path)
+      .then(function calculateRatio(size) {
+        return {
+          ratio: Number(size.height / size.width)
         };
       });
   }
@@ -107,6 +120,11 @@ function plugin(options) {
           var normalizedUnit = unquote(unescapeCss(unit || 'px'));
           return measure(normalizedPath, density, unitBase)
             .then(formatHeight.bind(null, normalizedUnit));
+        },
+        ratio: function ratio(path) {
+          var normalizedPath = unquote(unescapeCss(path));
+          return measureRatio(normalizedPath)
+            .then(formatRatio.bind());
         }
       }
     }));

--- a/test/assets.js
+++ b/test/assets.js
@@ -124,6 +124,19 @@ test('measures images with density provided', (t) =>
         t.is(result.css, "a { b: 80px 60px; c: 100px; d: 28.5px; }");
       }));
 
+test('measures images with unit and unitBase provided', (t) =>
+  process("a { " +
+    "b: size('vector.svg', 1, 'em', 16); " +
+    "c: width('picture.png', 1, 'em', 16); " +
+    "d: height('picture.png', 1, 'em', 16); " +
+    "}", {
+      basePath: 'fixtures',
+      loadPaths: ['fonts', 'images'],
+    })
+      .then((result) => {
+        t.is(result.css, "a { b: 10em 7.5em; c: 12.5em; d: 3.5625em; }");
+      }));
+
 test('throws when trying to measure a non-existing image', (t) =>
   process("a { b: size('non-existing.gif') }")
     .then(t.fail, (err) => {


### PR DESCRIPTION
This change allows you to output image dimensions in units other than pixels. This is useful in a few situations, such as:
- Specifying dimensions in ems on an element that should scale depending on the font-size of the container (eg. sprites that are sized relative to their accompanying text)
- Specifying dimensions in rems on an element that should scale depending on the document root font size (eg. making everything bigger/smaller for different sized viewports)

Hope submitting a pull request is OK, I've included docs and a new test.
